### PR TITLE
Add sharing of calendars

### DIFF
--- a/backend/api/v1/serializers/events.py
+++ b/backend/api/v1/serializers/events.py
@@ -191,7 +191,7 @@ class WriteEventSerializer(serializers.ModelSerializer):
         return data
 
 
-class ShareTheCalendarSerializer(serializers.ModelSerializer):
+class ShareCalendarSerializer(serializers.ModelSerializer):
     """
     Сериализация данных шеринга календаря.
     Owner - владелец календаря.

--- a/backend/api/v1/serializers/events.py
+++ b/backend/api/v1/serializers/events.py
@@ -2,7 +2,7 @@ from django.db import transaction
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
 
-from events.models import Calendar, Event
+from events.models import Calendar, Event, ShareTheCalendar
 
 
 class CalendarSerializer(serializers.ModelSerializer):
@@ -188,3 +188,48 @@ class WriteEventSerializer(serializers.ModelSerializer):
             raise serializers.ValidationError(message)
 
         return data
+
+
+class ShareTheCalendarSerializer(serializers.ModelSerializer):
+    """
+    Сериализация данных шеринга календаря.
+    Owner - владелец календаря.
+    user (share_to) - пользователь которому предоставляется доступ.
+    calendar - календарь, которым делится владелец.
+
+    Создание:
+    При создании записи в бд owner и calendar подставляются автоматически и
+    являются текущим календарем и текущим пользователем.
+
+    Валидация:
+    1. owner != user
+    2. Поля user и calendar уникальные
+    3. calendar является календарем созданным owner'ом
+    """
+    owner = serializers.SlugRelatedField(read_only=True, slug_field='email')
+    calendar = serializers.SlugRelatedField(read_only=True, slug_field='name')
+
+    class Meta:
+        model = ShareTheCalendar
+        fields = (
+            'owner',
+            'user',
+            'calendar',
+        )
+
+    # def create(self, validated_data):
+    # todo не пойму почему, но этот метод не вызывается. Пытался дебажить
+    #  но сюда так и не дошли операции.
+    #
+    #     request = self.context.get('request')
+    #     calendar_id = self.context['request'].parser_context['kwargs'].get(
+    #         'id')
+    #     calendar = get_object_or_404(Calendar, id=calendar_id)
+    #
+    #     if request and request.user.is_authenticated:
+    #         validated_data['owner'] = request.user
+    #         validated_data['calendar'] = calendar
+    #         instance = super().create(validated_data)
+    #         return instance
+    #     raise serializers.ValidationError(
+    #         'Пользователь не аутентифицирован.')

--- a/backend/api/v1/serializers/events.py
+++ b/backend/api/v1/serializers/events.py
@@ -240,3 +240,41 @@ class ShareCalendarSerializer(serializers.ModelSerializer):
             )
 
         return data
+
+
+class ReadOwnerShareCalendarSerializer(serializers.ModelSerializer):
+
+    owner = serializers.SlugRelatedField(read_only=True, slug_field='email')
+    user = serializers.SlugRelatedField(read_only=True, slug_field='email')
+    calendar = serializers.SerializerMethodField()
+
+    class Meta:
+        model = ShareCalendar
+        fields = (
+            'owner',
+            'user',
+            'calendar'
+        )
+
+    @staticmethod
+    def get_calendar(instance):
+        calendar = instance.calendar
+        return {
+            'id': calendar.id,
+            'name': calendar.name,
+            'color': calendar.color,
+        }
+
+
+class ReadUserShareCalendarSerializer(ReadOwnerShareCalendarSerializer):
+
+    class Meta:
+        model = ShareCalendar
+        fields = (
+            'id',
+            'owner',
+            'user',
+            'calendar',
+            'custom_name',
+            'custom_color',
+        )

--- a/backend/api/v1/serializers/events.py
+++ b/backend/api/v1/serializers/events.py
@@ -60,6 +60,7 @@ class ShortCalendarSerializer(serializers.ModelSerializer):
             'id',
             'name',
             'color',
+            'owner'
         )
 
 

--- a/backend/api/v1/serializers/events.py
+++ b/backend/api/v1/serializers/events.py
@@ -209,7 +209,8 @@ class ShareCalendarSerializer(serializers.ModelSerializer):
     3. calendar является календарем созданным owner'ом
     """
     owner = serializers.SlugRelatedField(read_only=True, slug_field='email')
-    user = serializers.SlugRelatedField(queryset=User.objects.all(), slug_field='email')
+    user = serializers.SlugRelatedField(queryset=User.objects.all(),
+                                        slug_field='email')
     calendar = serializers.SlugRelatedField(read_only=True, slug_field='name')
 
     class Meta:
@@ -234,10 +235,15 @@ class ShareCalendarSerializer(serializers.ModelSerializer):
         if not calendar:
             raise ValidationError('Нельзя поделиться чужим календарем')
         if user == owner:
-            raise ValidationError('Нельзя поделиться календарем с собой')
+            raise ValidationError(
+                {'user': 'Нельзя поделиться календарем с собой'}
+            )
         if share.exists():
             raise ValidationError(
-                'Вы уже поделились этим календарем с этим пользователем'
+                {
+                    'user':
+                    'Вы уже поделились этим календарем с этим пользователем',
+                }
             )
 
         return data
@@ -270,7 +276,6 @@ class ReadOwnerShareCalendarSerializer(serializers.ModelSerializer):
 
 
 class ReadUserShareCalendarSerializer(ReadOwnerShareCalendarSerializer):
-
     class Meta:
         model = ShareCalendar
         fields = (

--- a/backend/api/v1/serializers/events.py
+++ b/backend/api/v1/serializers/events.py
@@ -250,6 +250,13 @@ class ShareCalendarSerializer(serializers.ModelSerializer):
 
 
 class ReadOwnerShareCalendarSerializer(serializers.ModelSerializer):
+    """
+    Сериализация ответа для эндпойнта share_to_user.
+
+    Owner - владелец календаря.
+    users - массив пользователей, которым предоставляется доступ.
+    calendar - календарь, которым делится владелец.
+    """
     owner = serializers.SlugRelatedField(read_only=True, slug_field='email')
     users = serializers.SerializerMethodField()
     calendar = serializers.SerializerMethodField()
@@ -276,6 +283,15 @@ class ReadOwnerShareCalendarSerializer(serializers.ModelSerializer):
 
 
 class ReadUserShareCalendarSerializer(ReadOwnerShareCalendarSerializer):
+    """
+    Сериализация ответа для эндпойнта share_to_me.
+
+    id - идентификатор экземпляра ShareCalendar
+    owner - владелец календаря.
+    calendar - календарь, к которому предоставлен доступ
+    custom_name - поле названия для переопределения на фронте
+    custom_color - поле цвета для переопределения на фронте
+    """
     class Meta:
         model = ShareCalendar
         fields = (
@@ -288,6 +304,12 @@ class ReadUserShareCalendarSerializer(ReadOwnerShareCalendarSerializer):
 
 
 class ShareCalendarUpdateSerializer(serializers.ModelSerializer):
+    """
+    Сериализатор для PATCH-запроса на эндпойнт /:id/share.
+
+    Позволяет обновить поля custom_name и custom_color.
+    Возвращает объект сериализованый ShareCalendarSerializer.
+    """
     class Meta:
         model = ShareCalendar
         fields = ('custom_name', 'custom_color')

--- a/backend/api/v1/serializers/events.py
+++ b/backend/api/v1/serializers/events.py
@@ -217,6 +217,8 @@ class ShareCalendarSerializer(serializers.ModelSerializer):
             'owner',
             'user',
             'calendar',
+            'custom_name',
+            'custom_color',
         )
 
     def validate(self, data):

--- a/backend/api/v1/serializers/events.py
+++ b/backend/api/v1/serializers/events.py
@@ -3,6 +3,7 @@ from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
 
 from events.models import Calendar, Event, ShareCalendar
+from users.models import User
 
 
 class CalendarSerializer(serializers.ModelSerializer):
@@ -207,6 +208,7 @@ class ShareTheCalendarSerializer(serializers.ModelSerializer):
     3. calendar является календарем созданным owner'ом
     """
     owner = serializers.SlugRelatedField(read_only=True, slug_field='email')
+    user = serializers.SlugRelatedField(queryset=User.objects.all(), slug_field='email')
     calendar = serializers.SlugRelatedField(read_only=True, slug_field='name')
 
     class Meta:

--- a/backend/api/v1/views/events.py
+++ b/backend/api/v1/views/events.py
@@ -11,7 +11,7 @@ from drf_spectacular.utils import (
 )
 from rest_framework import status, viewsets
 from rest_framework.decorators import action
-from rest_framework.exceptions import NotFound, ValidationError
+from rest_framework.exceptions import ValidationError
 from rest_framework.response import Response
 
 from api.filters import EventFilter

--- a/backend/api/v1/views/events.py
+++ b/backend/api/v1/views/events.py
@@ -21,7 +21,7 @@ from api.permissions import (
 from api.v1.serializers.events import (
     CalendarSerializer,
     ReadEventSerializer,
-    ShareTheCalendarSerializer,
+    ShareCalendarSerializer,
     WriteEventSerializer,
 )
 from api.v1.utils.events.mixins import RequiredGETQueryParamMixin
@@ -91,7 +91,7 @@ class CalendarViewSet(viewsets.ModelViewSet):
 
     def get_serializer_class(self):
         if self.action == 'share':
-            return ShareTheCalendarSerializer
+            return ShareCalendarSerializer
         return CalendarSerializer
 
     @extend_schema(

--- a/backend/api/v1/views/events.py
+++ b/backend/api/v1/views/events.py
@@ -84,7 +84,10 @@ class CalendarViewSet(viewsets.ModelViewSet):
     def get_queryset(self):
         if self.request.user.is_superuser:
             return Calendar.objects.all()
-        return Calendar.objects.filter(owner=self.request.user)
+        return Calendar.objects.filter(
+            Q(owner=self.request.user) |
+            Q(share_calendars__user=self.request.user)
+        )
 
     def get_serializer_class(self):
         if self.action == 'share':

--- a/backend/api/v1/views/events.py
+++ b/backend/api/v1/views/events.py
@@ -254,8 +254,6 @@ class EventViewSet(RequiredGETQueryParamMixin, viewsets.ModelViewSet):
             global_events = Q(calendar__owner__is_superuser=True,
                               calendar__public=True)
             if self.request.user.is_authenticated:
-                shared_calendar = ShareCalendar.objects.filter(
-                    user=self.request.user)
                 return qs.filter(
                     Q(calendar__owner=self.request.user) | global_events)
             return qs.filter(global_events)

--- a/backend/api/v1/views/events.py
+++ b/backend/api/v1/views/events.py
@@ -142,6 +142,19 @@ class CalendarViewSet(viewsets.ModelViewSet):
         permission_classes=[ShareCalendarPermissions]
     )
     def share(self, request, pk):
+        """
+        Метод реализует функционал шаринга календаря.
+
+        Доступные HTTP-методы:
+         - POST — создание подписки. Необходимо передать email в теле запроса;
+         - DELETE — удаление подписки;
+         Если удаляет владелец календаря, то необходимо передать email
+         подписчика в теле запроса.
+         Если удаляет подписчик, то запрос отправляет без тела;
+         - PATCH — метод для обновления полей custom_name и custom_color,
+         для того, чтобы на фронте была возможность отрисовать название и цвет
+         отличные от оригинальных полей календаря.
+        """
         calendar = get_object_or_404(Calendar, pk=pk)
         serializer = self.get_serializer(data=request.data)
 
@@ -204,6 +217,7 @@ class CalendarViewSet(viewsets.ModelViewSet):
     )
     @action(methods=['get'], detail=False)
     def shared_to_me(self, request):
+        """Метод возвращает календари, которыми поделились с пользователем."""
         serializer = self.get_serializer(self.get_queryset(), many=True)
         return Response(serializer.data, status=status.HTTP_200_OK)
 
@@ -214,6 +228,7 @@ class CalendarViewSet(viewsets.ModelViewSet):
     )
     @action(methods=['get'], detail=False)
     def shared_to_user(self, request):
+        """Метод возвращает календари, которыми пользователь поделился."""
         serializer = self.get_serializer(self.get_queryset(), many=True)
         return Response(serializer.data, status=status.HTTP_200_OK)
 

--- a/backend/api/v1/views/events.py
+++ b/backend/api/v1/views/events.py
@@ -135,7 +135,7 @@ class CalendarViewSet(viewsets.ModelViewSet):
                              f'календарь {calendar}'},
                     status=status.HTTP_204_NO_CONTENT)
 
-            if calendar_user.exists():
+            elif calendar_user.exists():
                 calendar_user.delete()
                 return Response(
                     {'info': f'Вам больше не доступен календарь {calendar} '

--- a/backend/api/v1/views/events.py
+++ b/backend/api/v1/views/events.py
@@ -101,7 +101,7 @@ class CalendarViewSet(viewsets.ModelViewSet):
     def get_serializer_class(self):
         if self.action == 'share' and self.request.method == 'PATCH':
             return ShareCalendarUpdateSerializer
-        if self.action == 'share':
+        elif self.action == 'share':
             return ShareCalendarSerializer
         elif self.action == 'shared_to_me':
             return ReadUserShareCalendarSerializer
@@ -149,7 +149,7 @@ class CalendarViewSet(viewsets.ModelViewSet):
             calendar_owner = ShareCalendar.objects.filter(
                 owner=request.user, user__email=user, calendar=calendar)
             calendar_user = ShareCalendar.objects.filter(
-                owner__email=user, user=request.user, calendar=calendar)
+                owner__email=calendar.owner, user=request.user, calendar=calendar)
 
             if calendar_owner.exists():
                 calendar_owner.delete()
@@ -162,7 +162,7 @@ class CalendarViewSet(viewsets.ModelViewSet):
                 calendar_user.delete()
                 return Response(
                     {'info': f'Вам больше не доступен календарь {calendar} '
-                             f'пользователя {user} '},
+                             f'пользователя {calendar.owner}'},
                     status=status.HTTP_204_NO_CONTENT)
 
             return Response(

--- a/backend/api/v1/views/events.py
+++ b/backend/api/v1/views/events.py
@@ -184,10 +184,7 @@ class CalendarViewSet(viewsets.ModelViewSet):
                 owner=owner, user=user, calendar=calendar)
             if share.exists():
                 share.delete()
-                return Response(
-                    {'info': f'Пользователю "{user}" больше недоступен '
-                             f'календарь "{calendar}"'},
-                    status=status.HTTP_200_OK)
+                return Response(status=status.HTTP_204_NO_CONTENT)
             return Response(
                 {'info': (f'Пользователь "{user}" еще не подписан на '
                           f'календарь "{calendar}"')},

--- a/backend/api/v1/views/events.py
+++ b/backend/api/v1/views/events.py
@@ -258,7 +258,10 @@ class EventViewSet(RequiredGETQueryParamMixin, viewsets.ModelViewSet):
                               calendar__public=True)
             if self.request.user.is_authenticated:
                 return qs.filter(
-                    Q(calendar__owner=self.request.user) | global_events)
+                    Q(calendar__owner=self.request.user) |
+                    Q(calendar__share_calendars__user=self.request.user) |
+                    global_events
+                )
             return qs.filter(global_events)
 
         return qs

--- a/backend/events/admin.py
+++ b/backend/events/admin.py
@@ -1,7 +1,7 @@
 from django.contrib import admin
 from django.utils.html import format_html
 
-from events.models import Calendar, Event
+from events.models import Calendar, Event, ShareTheCalendar
 
 
 @admin.register(Calendar)
@@ -38,6 +38,16 @@ class EventAdmin(admin.ModelAdmin):
         'description',
         'day_off',
         'holiday',
+        'calendar',
+    )
+    empty_value_display = '-пусто-'
+
+
+@admin.register(ShareTheCalendar)
+class ShareTheCalendarAdmin(admin.ModelAdmin):
+    list_display = (
+        'owner',
+        'user',
         'calendar',
     )
     empty_value_display = '-пусто-'

--- a/backend/events/admin.py
+++ b/backend/events/admin.py
@@ -1,7 +1,7 @@
 from django.contrib import admin
 from django.utils.html import format_html
 
-from events.models import Calendar, Event, ShareTheCalendar
+from events.models import Calendar, Event, ShareCalendar
 
 
 @admin.register(Calendar)
@@ -43,7 +43,7 @@ class EventAdmin(admin.ModelAdmin):
     empty_value_display = '-пусто-'
 
 
-@admin.register(ShareTheCalendar)
+@admin.register(ShareCalendar)
 class ShareTheCalendarAdmin(admin.ModelAdmin):
     list_display = (
         'owner',

--- a/backend/events/models.py
+++ b/backend/events/models.py
@@ -119,6 +119,7 @@ class ShareCalendar(models.Model):
     Owner - Владелец календаря.
     User - Пользователь которому открыт доступ.
     Calendar - календарь, которым поделился владелец.
+    Custom_name и custom_color поля для кастомизации на фронте.
     User и Calendar уникальные поля и не могут повторяться.
     """
 

--- a/backend/events/models.py
+++ b/backend/events/models.py
@@ -139,6 +139,22 @@ class ShareCalendar(models.Model):
         verbose_name='Календарь',
         related_name='share_calendars',
     )
+    custom_name = models.CharField(
+        'Название',
+        max_length=100,
+        null=True,
+        blank=True,
+    )
+    custom_color = models.CharField(
+        'Код цвета в формате HEX',
+        max_length=7,
+        null=True,
+        blank=True,
+        validators=[RegexValidator(
+            regex='^#([a-fA-F0-9]{3}|[a-fA-F0-9]{6})$',
+            message='Недопустимые символы в коде цвета!'
+        )]
+    )
 
     class Meta:
         verbose_name = 'Доступ к календарю'

--- a/backend/events/models.py
+++ b/backend/events/models.py
@@ -112,7 +112,7 @@ class Event(models.Model):
             raise ValidationError(message)
 
 
-class ShareTheCalendar(models.Model):
+class ShareCalendar(models.Model):
     """
     Шеринг календаря владельцем, пользователю, который есть в базе.
     Owner - Владелец календаря.

--- a/backend/events/models.py
+++ b/backend/events/models.py
@@ -137,7 +137,7 @@ class ShareCalendar(models.Model):
         Calendar,
         on_delete=models.CASCADE,
         verbose_name='Календарь',
-        related_name='share_the_calendars',
+        related_name='share_calendars',
     )
 
     class Meta:

--- a/backend/events/tests/test_calendar_endpoints.py
+++ b/backend/events/tests/test_calendar_endpoints.py
@@ -46,7 +46,6 @@ class CalendarTest(BaseAPITestCase):
         Получение правильного кверисета календарей.
 
         У пользователя есть доступ только к своим календарям.
-        У админа есть доступ ко всем календарям.
         """
 
         response = self.owner.get(reverse('calendars-list'))
@@ -58,14 +57,6 @@ class CalendarTest(BaseAPITestCase):
         self.assertEqual(
             len(qs_calendars), amount_calendar_owner,
             'Пользователь должен получить только свои календари'
-        )
-
-        response = self.admin.get(reverse('calendars-list'))
-        qs_calendars = response.data
-        amount_all_calendars = Calendar.objects.all().count()
-        self.assertEqual(
-            len(qs_calendars), amount_all_calendars,
-            'Админ должен получить все календари'
         )
 
     def test_create_calendar(self):
@@ -103,7 +94,6 @@ class CalendarTest(BaseAPITestCase):
 
         У анонима нет доступа к редактированию календарей.
         У пользователя есть доступ к редактированию только своих календарей.
-        У админа есть доступ к редактированию всех календарей.
         """
 
         owner_id = User.objects.get(username='owner').id
@@ -112,7 +102,6 @@ class CalendarTest(BaseAPITestCase):
             (self.anon, status.HTTP_401_UNAUTHORIZED),
             (self.user, status.HTTP_404_NOT_FOUND),
             (self.owner, status.HTTP_200_OK),
-            (self.admin, status.HTTP_200_OK),
         )
 
         for client, expected_code in cases:
@@ -137,7 +126,6 @@ class CalendarTest(BaseAPITestCase):
 
         У анонима нет доступа к удалению календарей.
         У пользователя есть доступ к удалению только своих календарей.
-        У админа есть доступ к удалению всех календарей.
         """
 
         mock_delete.return_value = None
@@ -147,7 +135,6 @@ class CalendarTest(BaseAPITestCase):
             (self.anon, status.HTTP_401_UNAUTHORIZED),
             (self.user, status.HTTP_404_NOT_FOUND),
             (self.owner, status.HTTP_204_NO_CONTENT),
-            (self.admin, status.HTTP_204_NO_CONTENT),
         )
 
         for client, expected_code in cases:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,7 @@
 [flake8]
 ignore =
     W503,
+    R505,
 exclude =
     */migrations/,
     venv/,


### PR DESCRIPTION
@Annsjaw Дим, помимо того, что мы обсуждали на созвоне, добавил метод PATCH для изменения цвета/названия, добавил constraint в модели, пару валидаций, сериализатор для обновления, пермишен для доступа к calenadrs/:id/share/ и переработал DELETE-метод. (новая ветка потому, что твоя сильно устарела от актуальной в develop и проще было создать новую и сделать cherry-pick на твои коммиты) 

@olgalatkina @e-zybkin К сожалению, документация пока кривая вдоль и поперек ~не справляется библиотека с нашими запросами~ Постараюсь это исправить, но на первое время накидал для вас примеров. Если будут какие-то вопросы, то я на связи  :handshake:

### Добавлены следующие эндпойнты:
 - **GET ../calendars/share_to_user**. Возвращает все календари, которыми поделился пользователь.
<details>
  <summary>Ответ состоит из массива объектов: </summary>

  ```json
{
    "owner": "user@example.com",
    "users": [
        "user1@user.com",
        "user2@user.com",
    ],
    "calendar": {
        "id": 1,
        "name": "string",
        "color": "#000", 
    }
}
```
</details>
<hr>

 - **GET ../calendars/share_to_me**. Возвращает календари, к которым пользователю предоставили доступ. 
 <details>
  <summary>Ответ состоит из массива объектов: </summary>

  ```json
{
    "id": 0,
    "owner": "user@example.com",
    "calendar": {
          "id": 1,
          "name": "string",
          "color": "#000", 
    },
    "custom_name": "string",
    "custom_color": "#2Bd"
}
```
</details>
<hr>

 - **POST ../calendars/:id/share**. Эндпойнт для создания подписки на календарь. В теле запроса необходимо передать email пользователя, с которым делимся.
 <details>
  <summary>Запрос:</summary>

  ```json
{
    "user": "user@example.com"
}
```
</details>

 <details>
  <summary>Ответ сервера:</summary>

  ```json
{
    "owner": "owner@user.com",
    "user": "user@example.com",
    "calendar": "calendar_name",
    "custom_name": null,
    "custom_color": null
}
```
</details>
<hr>

 - **DELETE ../calendars/:id/share**. Удаление подписки. Доступно как владельцу календаря, так и подписчику. Если запрос исходит от владельца календаря, то необходимо передать email подписчика в теле. Если пользователь хочет отписаться от календаря, то тела нет.
  <details>
  <summary>Запрос от владельца:</summary>

  ```json
{
    "user": "user@example.com"
}
```
</details>

  <details>
  <summary>Пример ответа ⚠️⚠️⚠️:</summary>

  ```json
{
    "info": "Пользователю user@example.com больше недоступен календарь Название календаря"
}
```
@olgalatkina @e-zybkin **Тут стоит отдельно отметить, что статус при успехе удаления — 200, а не 204. Это связано с тем, что для 204 ответа нельзя добавить тело — оно просто не возвращается. Поэтому как компромисс, пока сделал так. Но по хорошему нужно сделать 204.**

</details>
<hr>

 - **PATCH ../calendars/:id/share**. Эндпойнт для добавления кастомного цвета и названия календаря для конечного пользователя.
  <details>
  <summary>Пример запроса:</summary>

  ```json
{
    "custom_name": "string",
    "custom_color": "#FFF"
}
```
  </details>

  <details>
  <summary>Пример ответа:</summary>

  ```json
{
    "owner": "owner@user.com",
    "user": "user@example.com",
    "calendar": "calendar_name",
    "custom_name": "string",
    "custom_color": "#FFF"
}
```
  </details>